### PR TITLE
Type defs gql

### DIFF
--- a/resolvers.js
+++ b/resolvers.js
@@ -1,0 +1,24 @@
+module.exports = {
+  Query: {
+    getUser: () => null,
+  },
+  Mutation: {
+    signupUser: async (_, { username, email, password }, { User }) => {
+      try {
+        const user = await User.findOne({ username });
+        if (user) {
+          throw new Error("User already exits");
+        }
+        const newUser = await new User({
+          username,
+          email,
+          password,
+        }).save();
+
+        return newUser;
+      } catch (error) {
+        console.log(error);
+      }
+    },
+  },
+};

--- a/server.js
+++ b/server.js
@@ -1,39 +1,20 @@
-const { ApolloServer, gql } = require("apollo-server");
+const fs = require("fs");
+const path = require("path");
+const { ApolloServer } = require("apollo-server");
 require("dotenv").config({ path: ".env" });
+
 const connectDb = require("./db");
 const User = require("./models/User");
 const Post = require("./models/Post");
-
 const db = process.env.MONGODB_URI;
 
 //connect to Mongo db
 connectDb(db);
 
-//define typeDefs,
-const typeDefs = gql`
-  type Todos {
-    task: String
-    completed: Boolean
-  }
+//Read typeDefs file from the file system
+const filePath = path.join(__dirname, "typeDefs.gql");
+const typeDefs = fs.readFileSync(filePath, "utf-8");
 
-  type Query {
-    getTodos: [Todos]
-  }
-`;
-
-//create a resolver
-// const resolvers = {
-//   Query: {
-//     getTodos: () => todos,
-//   },
-//   Mutation: {
-//     addTodo: (_, args) => {
-//       const todo = { task: args.task, completed: args.completed };
-//       todos.push(todo);
-//       return todo;
-//     },
-//   },
-// };
 //assign ApolloServer to the variable
 const server = new ApolloServer({
   typeDefs,

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const connectDb = require("./db");
 const User = require("./models/User");
 const Post = require("./models/Post");
 const db = process.env.MONGODB_URI;
+const resolvers = require("./resolvers");
 
 //connect to Mongo db
 connectDb(db);
@@ -18,6 +19,7 @@ const typeDefs = fs.readFileSync(filePath, "utf-8");
 //assign ApolloServer to the variable
 const server = new ApolloServer({
   typeDefs,
+  resolvers,
   context: {
     User,
     Post,

--- a/typeDefs.gql
+++ b/typeDefs.gql
@@ -25,3 +25,11 @@ type Message {
   messageDate: String
   messageUser: User!
 }
+
+type Query {
+  getUser: User
+}
+
+type Mutation {
+  signupUser(username: String!, email: String!, password: String!): User!
+}

--- a/typeDefs.gql
+++ b/typeDefs.gql
@@ -1,0 +1,27 @@
+type User {
+  _id: ID
+  username: String! @unique
+  email: String!
+  password: String!
+  avatar: String
+  joinDate: String
+  favorite: [Post]
+}
+
+type Post {
+  title: String!
+  imageUrl: String!
+  categories: [String]!
+  description: String
+  createdDate: String
+  likes: Int
+  createdBy: User!
+  message: [Message]
+}
+
+type Message {
+  _id: ID
+  messageBody: String!
+  messageDate: String
+  messageUser: User!
+}


### PR DESCRIPTION
note, root query is required when passing the typedefs to the apolloserver, 
see typedefs.gql for root query and mutation. 
mutations need to be named exactly as in resolvers.js 
